### PR TITLE
feat(gemini): 支持Gemini多 API 密钥轮换并添加关闭思考选项

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "com.brycewg.asrkb"
         minSdk =29
         targetSdk = 34
-        versionCode = 82
-        versionName = "3.3.0"
+        versionCode = 83
+        versionName = "3.3.1"
 
         // 仅打包 arm64-v8a 以控制体积；可按需扩展
         ndk {

--- a/app/src/main/java/com/brycewg/asrkb/store/Prefs.kt
+++ b/app/src/main/java/com/brycewg/asrkb/store/Prefs.kt
@@ -449,11 +449,19 @@ class Prefs(context: Context) {
     // Google Gemini 语音理解（通过提示词转写）
     var gemApiKey: String by stringPref(KEY_GEM_API_KEY, "")
 
+    fun getGeminiApiKeys(): List<String> {
+        return gemApiKey.split("\n").map { it.trim() }.filter { it.isNotBlank() }
+    }
+
     var gemModel: String by stringPref(KEY_GEM_MODEL, DEFAULT_GEM_MODEL)
 
     var gemPrompt: String
         get() = sp.getString(KEY_GEM_PROMPT, DEFAULT_GEM_PROMPT) ?: DEFAULT_GEM_PROMPT
         set(value) = sp.edit { putString(KEY_GEM_PROMPT, value) }
+
+    var geminiDisableThinking: Boolean
+        get() = sp.getBoolean(KEY_GEMINI_DISABLE_THINKING, false)
+        set(value) = sp.edit { putBoolean(KEY_GEMINI_DISABLE_THINKING, value) }
 
     // Soniox 语音识别
     var sonioxApiKey: String by stringPref(KEY_SONIOX_API_KEY, "")
@@ -936,6 +944,7 @@ class Prefs(context: Context) {
         private const val KEY_GEM_API_KEY = "gem_api_key"
         private const val KEY_GEM_MODEL = "gem_model"
         private const val KEY_GEM_PROMPT = "gem_prompt"
+        private const val KEY_GEMINI_DISABLE_THINKING = "gemini_disable_thinking"
         private const val KEY_VOLC_STREAMING_ENABLED = "volc_streaming_enabled"
         private const val KEY_VOLC_DDC_ENABLED = "volc_ddc_enabled"
         private const val KEY_VOLC_VAD_ENABLED = "volc_vad_enabled"

--- a/app/src/main/java/com/brycewg/asrkb/ui/settings/asr/AsrSettingsActivity.kt
+++ b/app/src/main/java/com/brycewg/asrkb/ui/settings/asr/AsrSettingsActivity.kt
@@ -511,6 +511,14 @@ class AsrSettingsActivity : AppCompatActivity() {
             bindString { prefs.gemPrompt = it }
         }
 
+        findViewById<MaterialSwitch>(R.id.switchGeminiDisableThinking).apply {
+            isChecked = prefs.geminiDisableThinking
+            setOnCheckedChangeListener { btn, isChecked ->
+                hapticTapIfEnabled(btn)
+                prefs.geminiDisableThinking = isChecked
+            }
+        }
+
         // Key guide link
         findViewById<com.google.android.material.button.MaterialButton>(R.id.btnGeminiGetKey).setOnClickListener { v ->
             hapticTapIfEnabled(v)

--- a/app/src/main/res/layout/activity_asr_settings.xml
+++ b/app/src/main/res/layout/activity_asr_settings.xml
@@ -619,7 +619,10 @@
             android:id="@+id/etGeminiApiKey"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="textPassword"
+            android:inputType="textMultiLine"
+            android:minLines="2"
+            android:maxLines="6"
+            android:gravity="top|start"
             android:textColor="?attr/colorOnSurface"
             android:textColorHint="?attr/colorOnSurfaceVariant" />
         </com.google.android.material.textfield.TextInputLayout>
@@ -656,6 +659,13 @@
             android:textColor="?attr/colorOnSurface"
             android:textColorHint="?attr/colorOnSurfaceVariant" />
         </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/switchGeminiDisableThinking"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/label_gemini_disable_thinking" />
 
         <com.google.android.material.button.MaterialButton
           android:id="@+id/btnGeminiGetKey"

--- a/app/src/main/res/values-en/strings_gemini.xml
+++ b/app/src/main/res/values-en/strings_gemini.xml
@@ -4,4 +4,5 @@
     <string name="label_gemini_api_key">Gemini API Key</string>
     <string name="label_gemini_model">Model (e.g., gemini-2.5-flash)</string>
     <string name="label_gemini_prompt">Transcription Prompt</string>
+    <string name="label_gemini_disable_thinking">Disable thinking (reduce latency)</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_gemini.xml
+++ b/app/src/main/res/values-zh-rCN/strings_gemini.xml
@@ -4,4 +4,5 @@
     <string name="label_gemini_api_key">Gemini API Key</string>
     <string name="label_gemini_model">模型（如：gemini-2.5-flash）</string>
     <string name="label_gemini_prompt">转录提示词（Prompt）</string>
+    <string name="label_gemini_disable_thinking">关闭思考（减少延迟）</string>
 </resources>

--- a/app/src/main/res/values/strings_gemini.xml
+++ b/app/src/main/res/values/strings_gemini.xml
@@ -4,4 +4,5 @@
     <string name="label_gemini_api_key">Gemini API Key</string>
     <string name="label_gemini_model">模型（如：gemini-2.5-flash）</string>
     <string name="label_gemini_prompt">转录提示词（Prompt）</string>
+    <string name="label_gemini_disable_thinking">关闭思考（减少延迟）</string>
 </resources>


### PR DESCRIPTION
允许用户在设置中输入多个 Gemini API 密钥，使用换行符分隔。在每次 ASR
请求时，系统将随机选择一个密钥进行调用，以提高可用性。

新增配置项用于关闭 Gemini 模型的“思考”阶段（thinking），这有助于显著减少
延迟，尤其适用于实时转录场景。根据模型类型，自动设置合适的 thinkingBudget
参数（Flash 为 0，Pro 为 128）。