### PR TITLE
Streamline local model installation interface

### DIFF
--- a/app/src/main/res/layout/activity_asr_settings.xml
+++ b/app/src/main/res/layout/activity_asr_settings.xml
@@ -902,14 +902,34 @@
           android:stepSize="1"
           android:layout_marginTop="2dp" />
 
-        <com.google.android.material.button.MaterialButton
-          android:id="@+id/btnSvDownloadModel"
-          style="@style/Widget.Material3.Button.TonalButton"
+        <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="12dp"
-          app:shapeAppearanceOverlay="@style/AsrkbShapeOverlayCapsule"
-          android:text="@string/btn_sv_download_model" />
+          android:orientation="horizontal"
+          android:gravity="center"
+          android:weightSum="2">
+
+          <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnSvDownloadModel"
+            style="@style/Widget.Material3.Button.TonalButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="4dp"
+            app:shapeAppearanceOverlay="@style/AsrkbShapeOverlayCapsule"
+            android:text="@string/btn_sv_download_model" />
+
+          <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnSvImportModel"
+            style="@style/Widget.Material3.Button.TonalButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="4dp"
+            app:shapeAppearanceOverlay="@style/AsrkbShapeOverlayCapsule"
+            android:text="@string/btn_sv_import_model" />
+        </LinearLayout>
 
         <com.google.android.material.button.MaterialButton
           android:id="@+id/btnSvClearModel"

--- a/app/src/main/res/values-ja/strings_sensevoice.xml
+++ b/app/src/main/res/values-ja/strings_sensevoice.xml
@@ -16,12 +16,17 @@
     <string name="btn_sv_download_model">SenseVoiceモデルをワンクリックでダウンロード</string>
     <string name="btn_sv_download_model_int8">SenseVoice（small int8、約160MB）をワンクリックでダウンロード</string>
     <string name="btn_sv_download_model_full">SenseVoice（small fp32、約850MB）をワンクリックでダウンロード</string>
+    <string name="btn_sv_import_model">ローカルファイルからモデルをインポート</string>
     <string name="btn_sv_clear_model">ダウンロードしたモデルをクリア</string>
     <string name="sv_download_status_downloading">ダウンロード中…%1$d%%</string>
     <string name="sv_download_status_extracting_progress">展開中… %1$d%%</string>
     <string name="sv_download_status_done">モデルがインストールされました</string>
     <string name="sv_download_status_failed">ダウンロードまたは展開失敗</string>
     <string name="sv_download_started_in_bg">バックグラウンドダウンロードを開始しました。進行状況は通知で確認してください。</string>
+    <string name="sv_import_started_in_bg">バックグラウンドインポートを開始しました。進行状況は通知で確認してください。</string>
+    <string name="sv_import_success">モデルのインポートに成功しました：%1$s</string>
+    <string name="sv_import_failed">モデルのインポートに失敗しました：%1$s</string>
+    <string name="sv_import_status_extracting">インポート中… %1$d%%</string>
     <string name="sv_clear_confirm_title">モデルクリアの確認</string>
     <string name="sv_clear_confirm_message">ダウンロードしたモデルファイルが削除されます。後で再ダウンロードできます。続行しますか？</string>
     <string name="sv_clear_done">モデルがクリアされました</string>

--- a/app/src/main/res/values-zh-rCN/strings_sensevoice.xml
+++ b/app/src/main/res/values-zh-rCN/strings_sensevoice.xml
@@ -16,12 +16,17 @@
     <string name="btn_sv_download_model">一键下载 SenseVoice 模型</string>
     <string name="btn_sv_download_model_int8">一键下载 SenseVoice 模型（small int8，约 160MB）</string>
     <string name="btn_sv_download_model_full">一键下载 SenseVoice 模型（small fp32，约 850MB）</string>
+    <string name="btn_sv_import_model">从本地导入模型</string>
     <string name="btn_sv_clear_model">清除已下载模型</string>
     <string name="sv_download_status_downloading">下载中… %1$d%%</string>
     <string name="sv_download_status_extracting_progress">解压中… %1$d%%</string>
     <string name="sv_download_status_done">模型已安装</string>
     <string name="sv_download_status_failed">下载或解压失败</string>
     <string name="sv_download_started_in_bg">已开始后台下载，请到通知栏查看进度</string>
+    <string name="sv_import_started_in_bg">已开始后台导入，请到通知栏查看进度</string>
+    <string name="sv_import_success">模型导入成功：%1$s</string>
+    <string name="sv_import_failed">模型导入失败：%1$s</string>
+    <string name="sv_import_status_extracting">导入中… %1$d%%</string>
     <string name="sv_clear_confirm_title">确认清除模型？</string>
     <string name="sv_clear_confirm_message">将删除已下载的模型文件，可稍后重新下载。是否继续？</string>
     <string name="sv_clear_done">已清除模型</string>

--- a/app/src/main/res/values-zh-rTW/strings_sensevoice.xml
+++ b/app/src/main/res/values-zh-rTW/strings_sensevoice.xml
@@ -16,12 +16,17 @@
     <string name="btn_sv_download_model">一鍵下載 SenseVoice 模型</string>
     <string name="btn_sv_download_model_int8">一鍵下載 SenseVoice 模型（small int8，約 160MB）</string>
     <string name="btn_sv_download_model_full">一鍵下載 SenseVoice 模型（small fp32，約 850MB）</string>
+    <string name="btn_sv_import_model">從本機匯入模型</string>
     <string name="btn_sv_clear_model">清除已下載模型</string>
     <string name="sv_download_status_downloading">下載中… %1$d%%</string>
     <string name="sv_download_status_extracting_progress">解壓中… %1$d%%</string>
     <string name="sv_download_status_done">模型已安裝</string>
     <string name="sv_download_status_failed">下載或解壓失敗</string>
     <string name="sv_download_started_in_bg">已開始背景下載，請到通知欄查看進度</string>
+    <string name="sv_import_started_in_bg">已開始背景匯入，請到通知欄查看進度</string>
+    <string name="sv_import_success">模型匯入成功：%1$s</string>
+    <string name="sv_import_failed">模型匯入失敗：%1$s</string>
+    <string name="sv_import_status_extracting">匯入中… %1$d%%</string>
     <string name="sv_clear_confirm_title">確認清除模型？</string>
     <string name="sv_clear_confirm_message">將刪除已下載的模型檔案，可稍後重新下載。是否繼續？</string>
     <string name="sv_clear_done">已清除模型</string>

--- a/app/src/main/res/values/strings_sensevoice.xml
+++ b/app/src/main/res/values/strings_sensevoice.xml
@@ -16,12 +16,17 @@
     <string name="btn_sv_download_model">One-click download SenseVoice model</string>
     <string name="btn_sv_download_model_int8">One-click download SenseVoice (small int8, ~160MB)</string>
     <string name="btn_sv_download_model_full">One-click download SenseVoice (small fp32, ~850MB)</string>
+    <string name="btn_sv_import_model">Import model from local file</string>
     <string name="btn_sv_clear_model">Clear downloaded model</string>
     <string name="sv_download_status_downloading">Downloading… %1$d%%</string>
     <string name="sv_download_status_extracting_progress">Extracting… %1$d%%</string>
     <string name="sv_download_status_done">Model installed</string>
     <string name="sv_download_status_failed">Download or extraction failed</string>
     <string name="sv_download_started_in_bg">Started background download. Check notification for progress.</string>
+    <string name="sv_import_started_in_bg">Started background import. Check notification for progress.</string>
+    <string name="sv_import_success">Model imported successfully: %1$s</string>
+    <string name="sv_import_failed">Model import failed: %1$s</string>
+    <string name="sv_import_status_extracting">Importing… %1$d%%</string>
     <string name="sv_clear_confirm_title">Confirm clear model?</string>
     <string name="sv_clear_confirm_message">This will delete downloaded model files. You can re-download later. Continue?</string>
     <string name="sv_clear_done">Model cleared</string>


### PR DESCRIPTION
1. 简化SenseVoice下载按钮文本
   - 将按钮名称从"一键下载Sensevoice模型(small int8,约160MB)"改为"一键下载Sensevoice模型"
   - 统一四种语言(中文简体、繁体、英文、日文)的按钮文本
   - 移除末尾的详细信息，与其他下载渠道保持一致

2. 添加本地文件导入功能
   - 在下载按钮右侧新增"从本地导入模型"按钮
   - 支持选择.tar.bz2压缩包文件进行导入
   - 两个按钮并排显示，提供更好的用户体验

3. 智能模型识别
   - 根据导入文件内容自动判断模型类型(SenseVoice/Paraformer/Zipformer)
   - 检测关键文件特征(tokens.txt、model.onnx等)来识别模型
   - 导入失败时显示详细的错误信息

4. 完善的导入通知
   - 显示导入进度(复制和解压)
   - 成功时显示模型类型和版本信息
   - 失败时显示具体的失败原因

技术实现:
- AsrSettingsActivity: 添加文件选择器和导入按钮点击事件
- ModelDownloadService: 实现startImport、doImportTask、detectModelType等方法
- NotificationHandler: 支持动态更新模型类型
- 新增多语言字符串资源支持导入功能

该优化使得用户可以更方便地从本地文件导入已下载的模型，无需重复下载。