### PR TITLE
Add toggle dialog prompts to settings switches

### DIFF
--- a/app/src/main/java/com/brycewg/asrkb/ui/settings/ai/AiPostSettingsActivity.kt
+++ b/app/src/main/java/com/brycewg/asrkb/ui/settings/ai/AiPostSettingsActivity.kt
@@ -3,6 +3,8 @@ package com.brycewg.asrkb.ui.settings.ai
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.view.HapticFeedbackConstants
+import android.view.View
 import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
@@ -14,6 +16,7 @@ import com.brycewg.asrkb.R
 import com.brycewg.asrkb.asr.LlmPostProcessor
 import com.brycewg.asrkb.store.Prefs
 import com.brycewg.asrkb.store.PromptPreset
+import com.brycewg.asrkb.ui.installExplainedSwitch
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.materialswitch.MaterialSwitch
@@ -103,9 +106,16 @@ class AiPostSettingsActivity : AppCompatActivity() {
         // AI 编辑默认范围开关：使用上次识别结果
         switchAiEditPreferLastAsr = findViewById(R.id.switchAiEditPreferLastAsr)
         switchAiEditPreferLastAsr.isChecked = prefs.aiEditDefaultToLastAsr
-        switchAiEditPreferLastAsr.setOnCheckedChangeListener { _, isChecked ->
-            prefs.aiEditDefaultToLastAsr = isChecked
-        }
+        switchAiEditPreferLastAsr.installExplainedSwitch(
+            context = this,
+            titleRes = R.string.label_ai_edit_default_use_last_asr,
+            offDescRes = R.string.feature_ai_edit_default_use_last_asr_off_desc,
+            onDescRes = R.string.feature_ai_edit_default_use_last_asr_on_desc,
+            preferenceKey = "ai_edit_default_use_last_asr_explained",
+            readPref = { prefs.aiEditDefaultToLastAsr },
+            writePref = { v -> prefs.aiEditDefaultToLastAsr = v },
+            hapticFeedback = { hapticTapIfEnabled(it) }
+        )
 
         // 少于特定字数跳过 AI 后处理
         etSkipAiUnderChars = findViewById(R.id.etSkipAiUnderChars)
@@ -446,6 +456,15 @@ class AiPostSettingsActivity : AppCompatActivity() {
         val currentText = this.text?.toString() ?: ""
         if (currentText != newText) {
             setText(newText)
+        }
+    }
+
+    /**
+     * Performs haptic feedback if enabled in preferences
+     */
+    private fun hapticTapIfEnabled(view: View?) {
+        if (prefs.micHapticEnabled) {
+            view?.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
         }
     }
 }

--- a/app/src/main/res/layout/activity_floating_settings.xml
+++ b/app/src/main/res/layout/activity_floating_settings.xml
@@ -90,13 +90,6 @@
         android:layout_marginTop="12dp"
         android:text="@string/label_floating_write_compat" />
 
-      <TextView
-          android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="6dp"
-        android:textColor="@android:color/darker_gray"
-        android:text="@string/desc_floating_write_compat" />
-
       <com.google.android.material.textfield.TextInputLayout
           android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -122,13 +115,6 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="12dp"
         android:text="@string/label_floating_write_paste" />
-
-      <TextView
-          android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="6dp"
-        android:textColor="@android:color/darker_gray"
-        android:text="@string/desc_floating_write_paste" />
 
       <com.google.android.material.textfield.TextInputLayout
           android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,6 +232,26 @@
   <string name="feature_headset_mic_priority_on_desc">Prioritizes the headset microphone when available. Experimental feature, requires Bluetooth permission and nearby devices permission.</string>
 
   <!-- ============================================== -->
+  <!-- AI Post-processing Settings - Feature Explanations -->
+  <!-- ============================================== -->
+
+  <!-- AI edit default use last ASR -->
+  <string name="feature_ai_edit_default_use_last_asr_off_desc">AI edit will target the text currently selected or the entire input field.</string>
+  <string name="feature_ai_edit_default_use_last_asr_on_desc">AI edit will default to operating on the last recognition result, convenient for quick edits after voice input.</string>
+
+  <!-- ============================================== -->
+  <!-- Other Settings - Feature Explanations -->
+  <!-- ============================================== -->
+
+  <!-- Disable ASR history -->
+  <string name="feature_disable_asr_history_off_desc">Recognition history will be saved for later review and management.</string>
+  <string name="feature_disable_asr_history_on_desc">Recognition history will not be saved. Enabling this will clear all existing history. Use this to protect your privacy.</string>
+
+  <!-- Disable usage statistics -->
+  <string name="feature_disable_usage_stats_off_desc">Usage statistics (total characters and aggregated data) will be collected for your reference.</string>
+  <string name="feature_disable_usage_stats_on_desc">Usage statistics will not be collected. Enabling this will clear all existing statistics. Use this to protect your privacy.</string>
+
+  <!-- ============================================== -->
   <!-- ASR Settings - Feature Explanations -->
   <!-- ============================================== -->
 

--- a/app/src/main/res/values/strings_floating.xml
+++ b/app/src/main/res/values/strings_floating.xml
@@ -37,4 +37,24 @@
     <string name="toast_move_mode_on">Move mode enabled. Tap the ball to exit.</string>
     <string name="label_reset_floating_position">Reset floating ball position</string>
     <string name="toast_floating_position_reset">Floating ball position reset</string>
+
+    <!-- ============================================== -->
+    <!-- Floating Settings - Feature Explanations -->
+    <!-- ============================================== -->
+
+    <!-- Floating ASR -->
+    <string name="feature_floating_asr_off_desc">The floating ball will not be displayed. Voice recognition can only be accessed through the keyboard.</string>
+    <string name="feature_floating_asr_on_desc">Enables the floating ball for voice recognition. You can use voice input from anywhere, even when the keyboard is hidden. Requires display overlay and accessibility permissions.</string>
+
+    <!-- Floating only when IME visible -->
+    <string name="feature_floating_only_when_ime_visible_off_desc">The floating ball remains visible even when the keyboard is hidden.</string>
+    <string name="feature_floating_only_when_ime_visible_on_desc">The floating ball is automatically hidden when the keyboard is hidden and shown when the keyboard appears. Requires accessibility permission to detect keyboard state.</string>
+
+    <!-- Floating write compatibility mode -->
+    <string name="feature_floating_write_compat_off_desc">Uses standard Accessibility API to insert text. Works for most apps.</string>
+    <string name="feature_floating_write_compat_on_desc">For target apps, uses Select-All + Paste method to avoid background placeholder text contamination. The clipboard may be temporarily used (best-effort restore). Useful for apps like Telegram and Douyin.</string>
+
+    <!-- Floating write paste -->
+    <string name="feature_floating_write_paste_off_desc">Recognition results are inserted directly into the input field via Accessibility API.</string>
+    <string name="feature_floating_write_paste_on_desc">For target packages, recognition results are copied to clipboard only, without automatic insertion. Useful for apps where direct insertion doesn\'t work properly.</string>
 </resources>


### PR DESCRIPTION
为 AI 设置、悬浮球设置和其他设置页面的开关添加统一的功能说明弹窗，
提升用户体验，帮助用户首次使用时了解各项功能。

主要更改：

1. 字符串资源 (strings.xml, strings_floating.xml):
   - 添加 AI 编辑默认范围开关的功能说明
   - 添加悬浮球相关开关的功能说明（4个）
   - 添加隐私设置开关的功能说明（2个）

2. AiPostSettingsActivity.kt:
   - switchAiEditPreferLastAsr 改用 installExplainedSwitch
   - 添加触觉反馈支持

3. FloatingSettingsActivity.kt:
   - switchFloatingAsr 改用 installExplainedSwitch（包含权限检查）
   - switchFloatingOnlyWhenImeVisible 改用 installExplainedSwitch（包含权限检查）
   - switchFloatingWriteCompat 改用 installExplainedSwitch
   - switchFloatingWritePaste 改用 installExplainedSwitch

4. OtherSettingsActivity.kt:
   - swDisableHistory 改用 installExplainedSwitch（保留清空历史确认）
   - swDisableStats 改用 installExplainedSwitch（保留清空统计确认）
   - 添加触觉反馈支持

5. activity_floating_settings.xml:
   - 删除 switchFloatingWriteCompat 和 switchFloatingWritePaste 下的 冗余描述文本（功能说明已通过弹窗展示）

所有开关现在具有一致的用户体验：
- 首次点击时显示功能说明弹窗
- 可选择"不再提示"
- 集成权限检查和确认对话框
- 统一的触觉反馈